### PR TITLE
genometools path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,7 @@ install:
   - sudo apt-get -y install genometools
   - pip3 install pyyaml gffutils
   - python3 setup.py install
+env:
+  - GENOMETOOLS_PATH='/usr/bin/gt'
 script:
   - "./run_tests.sh" 

--- a/gffmunger-config.yml
+++ b/gffmunger-config.yml
@@ -40,7 +40,8 @@ annotated_feature_types :
 only_transfer_anot_to_mRNA : False
 
 # For use of genometools to validate GFF3 input.
-gt_path                 : '/usr/bin/gt'
+# gt_path                 : '/usr/bin/gt'
+gt_path                 : '/software/pathogen/external/apps/usr/local/genometools-1.5.9/bin/gt'
 gff3_validator_tool     : 'gff3validator'
 gff3_validation_timeout : 60
 

--- a/gffmunger/GFFMunger.py
+++ b/gffmunger/GFFMunger.py
@@ -28,6 +28,7 @@ class GFFMunger:
          self.input_file_arg  = '/dev/zero'
          self.output_file     = 'no_such_file'
          self.config_file     = 'gffmunger-config.yml'
+         self.gt_path_arg     = None
       else:
          # this should be the normal case
          self.verbose         = options.verbose
@@ -38,7 +39,8 @@ class GFFMunger:
          self.input_file_arg  = options.input_file
          self.output_file     = options.output_file
          self.config_file     = options.config
-         
+         self.gt_path_arg     = options.genometools
+
       # set up logger
       self.logger = logging.getLogger(__name__)
       def setLogLevel(level):
@@ -78,6 +80,18 @@ class GFFMunger:
          self.logger.critical("required parameter "+str(e)+" missing from configuration in "+self.config_file)
          raise
       config_fh.close()
+      
+      # apply any environment vaiables that override config file params
+      if 'GENOMETOOLS_PATH' in os.environ:
+         self.gt_path_env_var = os.environ['GENOMETOOLS_PATH']
+         if self.gt_path_env_var:
+            self.logger.info("Using genometools path from environment variable GENOMETOOLS_PATH ("+self.gt_path_env_var+") instead of "+self.config_file+"value "+self.gt_path)
+            self.gt_path = self.gt_path_env_var
+      
+      # apply any CLI args that override config file params
+      if self.gt_path_arg:
+         self.logger.info("Using genometools path from CLI argument ("+self.gt_path_arg+") instead of "+self.config_file+"value "+self.gt_path)
+         self.gt_path = self.gt_path_arg
 
       self.logger.debug("Using genometools "+self.gt_path+" for validation with the tool "+self.gff3_validator_tool+" (timeout "+str(self.gff3_valiation_timeout)+")")
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,1 @@
-python3 -m unittest discover --start-directory gffmunger/tests/ --pattern  '*_tests.py' "$@"
+env GENOMETOOLS_PATH='/usr/bin/gt' python3 -m unittest discover --start-directory gffmunger/tests/ --pattern  '*_tests.py' "$@"

--- a/scripts/gffmunger
+++ b/scripts/gffmunger
@@ -39,6 +39,7 @@ parser.add_argument('--fasta-file', '-a',    type=str,                          
 parser.add_argument('--input-file', '-i',    type=str,                                             help = 'Read GFF3 from file instead of STDIN')
 parser.add_argument('--output-file', '-o',   type=str,                                             help = 'Write GFF3 to file instead of STDOUT')
 parser.add_argument('--config',  '-c',       type=str,               default = config_file_path,   help = 'Config file [%(default)s]')
+parser.add_argument('--genometools', '-g',   type=str,                                             help = 'genometools path (override path in config)')
 parser.add_argument('--version',             action='version',       version = str(version),       help = 'Print version and exit')
 
 options = parser.parse_args()


### PR DESCRIPTION
set genometools path to /software/pathogen/whatevs; allow alternarte path to be set with GENOMETOOLS_PATH environment variable (needed for tests on VMs incl. travis) or --genometools CLI arg

so we should be covered now